### PR TITLE
local.conf: enforce gstreamer version 1.8.3 for omap-a15 machines

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -48,3 +48,12 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 # generating the feeds
 #PRSERV_HOST = "localhost:0"
 
+# using ducati gstreamer plugin by TI implies the gstreamer version from
+# morty release (1.8.3)
+PREFERRED_VERSION_gstreamer1.0_omap-a15 = "1.8.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly_omap-a15 = "1.8.3"
+PREFERRED_VERSION_gstreamer1.0-libav_omap-a15 = "1.8.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-good_omap-a15 = "1.8.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-bad_omap-a15 = "1.8.3"
+PREFERRED_VERSION_gstreamer1.0-plugins-base_omap-a15 = "1.8.3"
+


### PR DESCRIPTION
This is a requirement for using the ducati plugin by TI (provides
HW accelerated video decoding and encoding).

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>