### PR TITLE
Revert "default.xml: use fork of meta-96boards to get mali450r6p001re…

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -9,10 +9,10 @@
   
   <default revision="morty" sync-j="4"/>
   
+  <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
   <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="6edb45804c5e532fdbca31e9d358d9052eaee90b"/>
   <project name="WebPlatformForEmbedded/meta-wpe" path="layers/meta-wpe" remote="github" revision="1d712bb6e557411bdd3e358b5d9098cff7df15b7"/>
-  <project name="andrey-konovalov/meta-96boards" path="layers/meta-96boards" remote="github" revision="morty-mali450r6p001rel0"/>
   <project name="cpriouzeau/meta-st-cannes2" path="layers/meta-st-cannes2" remote="github"/>
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>


### PR DESCRIPTION
…l0 driver"

This reverts commit acfbe9877fd0e76e57da83c1b579efebde5f2c77.

Now that the 32-bit variant of mali driver for HiKey ver r7p0_01rel0
is available from developer.arm.com, we can switch the manifest
back to mainline meta-96boards.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>