### PR TITLE
fix lhg-westeros-wpe build to use LinaroCDM

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -60,3 +60,6 @@ PREFERRED_VERSION_gstreamer1.0-plugins-base_omap-a15 = "1.8.3"
 # workaround the issue cased cairo_%.bbappend from meta-wpe
 # (it enables egl for the native package) :
 PACKAGECONFIG_remove_pn-cairo-native = "egl"
+
+# mask Metrological's CDM to use Linaro's CDM
+BBMASK += "meta-wpe/recipes-drm/opencdm/"


### PR DESCRIPTION
Use proper LinaroCDM, instead of Metrological's CDM