### PR TITLE
meta-clang: Use Thud branch instead of master

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -17,7 +17,7 @@
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
-  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github" revision="master"/>
+  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="linaro-mmwg/meta-freescale" path="layers/meta-freescale" remote="github" revision="mmwg-master"/>
   <project name="linaro-mmwg/meta-lhg" path="layers/meta-lhg" remote="github"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>


### PR DESCRIPTION
Currently, the master branch includes Clang 8.0, which fails
to build [1]. While on Thud, let's use the Thud branch.

[1] https://github.com/kraj/meta-clang/issues/106

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>