### PR TITLE
default.xml: remove meta-wpe pinning

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -32,5 +32,5 @@
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
-  <project name="petegriffin/meta-wpe" path="layers/meta-wpe" remote="github" revision="54231d6ed6787c539334bfb759fb0aadc27866d8"/>
+  <project name="petegriffin/meta-wpe" path="layers/meta-wpe" remote="github"/>
 </manifest>


### PR DESCRIPTION
meta-wpe needs to be bumped to get dunfel compatability.
But we now have a master-pinned manifest for a pinned
(hopefully stable) build. So we will leave this pointing
at all the master branches.

Should fix following ci build failure
https://ci.linaro.org/job/lhg-oe-wpe-master/DISTRO=rpb-wayland,MACHINE=imx8mqevk,label=docker-stretch-amd64-lhg/3/console

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>